### PR TITLE
docker-compose: add the tdex-initializer container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
       - WALLET_PASSWORD
     image: ghcr.io/tdex-network/tdexd:latest
     restart: unless-stopped
-    links: 
-      - tdexd
     command: bash -c "tdex config init && tdex config set rpcserver tdexd:9000 && tdex unlock --password ${WALLET_PASSWORD}"
     depends_on:
      - tdexd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,17 @@ services:
       - ${TDEX_PATH}:/.tdex-daemon
       - ${SSL_CERT_PATH}:/cert.pem
       - ${SSL_KEY_PATH}:/key.pem
+  tdexd-init:
+    container_name: "tdexd-initializer"
+    environment: 
+      - WALLET_PASSWORD
+    image: ghcr.io/tdex-network/tdexd:latest
+    restart: unless-stopped
+    links: 
+      - tdexd
+    command: bash -c "tdex config init && tdex config set rpcserver tdexd:9000 && tdex unlock --password ${WALLET_PASSWORD}"
+    depends_on:
+     - tdexd
   feederd:
     container_name: "feederd"
     image: ghcr.io/tdex-network/feederd:latest


### PR DESCRIPTION
**This PR adds a `tdexd-initializer` container**

The tdexd-initializer just use tdex operator cli to unlock the wallet according to the env variable `WALLET_PASSWORD`. 
Thus, when the user `docker-compose up` --> an `unlock` request is automatically send to the daemon. However if the tdexd failed, it needs to manually restart `tdexd-initializer` to re-unlock the wallet (is it really bad? after all if the daemon has failed, human intervention is necessary. At least for debugging.)

A (bad) solution could be run a loop script in `tdexd-initializer` which performs `unlock` every X ms.

@tiero 

it closes #2 