### PR TITLE
Support auto-unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ export EXPLORER=zzz
 
 #### TLS
 
-Uncomment the in the compose file (`docker-compose.yml`) the TLS related stuff and export ENV with the asbolute path to the SSL Certificate and Key to be used.
+Uncomment in the compose file (`docker-compose.yml`) the TLS related stuff and export ENV with the asbolute path to the SSL Certificate and Key to be used.
 
 ```sh
 $ export SSL_CERT_PATH=/path/to/fullchain.pem
@@ -54,7 +54,7 @@ Add this compose service at the bottom of the compose file (either `docker-compo
       - ./tor:/var/lib/tor/hidden_service/
 ```
 
-Export you Onion service V3 private key or leave it blank to create a new one
+Export your Onion service V3 private key or leave it blank to create a new one
 
 ```sh
 $ export ONION_KEY=base64_Onion_V3_Private_Key
@@ -78,6 +78,35 @@ $ docker logs feederd --tail 20
 
 ```sh
 $ docker exec tor onions
+```
+
+## **New** Auto-unlock
+
+#### Unlocker
+
+Starting from tdexd v0.5.0 and above, the image comes with a new `unlockerd` embedded binary useful to automatize the unlocking of the daemon's wallet once (re)started and initialized.
+
+The unlocker supports different ways to source the password from a certain _provider_ (file, AWS KMS, Kubernetes, Hashicorp Vault).  
+At the moment, the only available option is providing a file containing the plaintext password to unlock the daemon's wallet.
+
+Create the password file (you can name whatever you want), like for example:
+
+```sh
+$ echo "mypassword" > path/to/pwd.txt
+```
+
+Them, uncomment in the compose file the [volume](docker-compose.yml#L35) related to the Unlocker service and export ENV with the path to the newly created file:
+
+```sh
+$ export PWD_PATH=path/to/pwd.txt
+```
+
+After starting up the daemon, you can execute the unlocker binary:
+
+```sh
+$ alias unlockerd="docker exec -it tdexd unlockerd"
+
+$ unlockerd --password_path /pwd.txt --rpcserver 0.0.0.0:9000
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ export ONION_KEY=base64_Onion_V3_Private_Key
 ## Run 
 
 ```sh
-$ docker-compose -f docker-compose.yml up -d
+$ docker-compose up -d
 ```
 
 Check the Logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       #### TLS only ####
       #- ${SSL_CERT_PATH}:/trade.crt
       #- ${SSL_KEY_PATH}:/trade.key
+      #### Unlocker ####
+      #- ${PWD_PATH}:/pwd.txt
 
   # Pull prices from kraken and push to the daemon
   feederd:


### PR DESCRIPTION
This adds a commented volume to the tdexd container to be used for the unlocker service.

This also adds info in the README on how to setup and use the new auto-unlock feature of tdexd v0.5.0 and above.

Please @tiero review this.