### PR TITLE
Update feeder config file && Improve description in TLS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ By default, the daemon service is configured to enable TLS encryption for the Op
 The generation of the TLS key and certificate file for this interface are up to the daemon itself.  
 If you want to run the box on a remote machine with a static IP (and possibly a DNS name), you need to uncomment one or both [TDEX_OPERATOR_EXTRA IP | TDEX_OPERATOR_EXTRA_DOMAIN](docker-compose.yml#L21) env vars to let the daemon create the right certificate that, for example, will allow you to use the Operator CLI remotely. Exceptionally for this case, if you are also going to run the feeder service, you'll need to change the default config file like follows:
 - change the [hostname of the rpc_address](feederd/config.json#L13) (default `tdexd`) and use the static IP or DNS name.
-- uncomment the [volumes](docker-compose.yml#54) in the compose file to mount the macaroon and TLS certificate to the feeder service and change the [macaroons_path](feederd/config.json#L11) and [tls_cert_path](feederd/config.json#L12) to `/price.macaroon` and `/cert.pem` respectively.
+- uncomment the [feederd's volumes](docker-compose.yml#54) section in the compose file to mount the macaroon and TLS certificate to the feeder service and change the [macaroons_path](feederd/config.json#L11) and [tls_cert_path](feederd/config.json#L12) to `/price.macaroon` and `/cert.pem` respectively.
 Last but not least, don't forget to open the port where the Operator interface listens to (default `9000`) and allow in-going and out-going traffic over it on your router.
 
 ### Onion

--- a/README.md
+++ b/README.md
@@ -29,18 +29,21 @@ $ export EXPLORER=zzz
 To enable TLS encryption on the Trade interface of the daemon, you have to generate your own TLS key and certificate files. Once this is done, export the ENV variables with the absolute path of the files: 
 
 ```sh
-$ export SSL_CERT_PATH=/path/to/certificate.crt
-$ export SSL_KEY_PATH=/path/to/privatekey.key
+$ export SSL_CERT_PATH=/path/to/fullchain.pem
+$ export SSL_KEY_PATH=/path/to/privatekey.pem
 ```
 
 The last step is to uncomment in the compose file (`docker-compose.yml`) the lines related to TLS for Trade interface.
 
 #### Operator interface
 
-By default, the daemon service is configured to enable TLS encryption for the Operator interface. It's enough to uncomment [this line](docker-compose.yml#L18) to disable it.
+By default, the daemon service is configured to enable TLS encryption for the Operator interface. It's enough to uncomment [TDEX_NO_MACAROONS](docker-compose.yml#L18) env var to disable it.
 
 The generation of the TLS key and certificate file for this interface are up to the daemon itself.  
-If you want to run the box on a remote machine with a static IP (and possibly a DNS name), you need to uncomment one or both [these lines](docker-compose.yml#L21) to let the daemon create the right certificate that, for example, will allow you to use the Operator CLI remotely. Exceptionally for this case, if you are also going to run the feeder service, you'll need to change the [default address in its config file](feederd/config.json#L12) (default `tdexd`) and use the static IP or DNS name. Last but not least, don't forget to open the port where the Operator interface listens to (default `9000`) and allow in-going and out-going traffic over it on your router.
+If you want to run the box on a remote machine with a static IP (and possibly a DNS name), you need to uncomment one or both [TDEX_OPERATOR_EXTRA IP | TDEX_OPERATOR_EXTRA_DOMAIN](docker-compose.yml#L21) env vars to let the daemon create the right certificate that, for example, will allow you to use the Operator CLI remotely. Exceptionally for this case, if you are also going to run the feeder service, you'll need to change the default config file like follows:
+- change the [hostname of the rpc_address](feederd/config.json#L13) (default `tdexd`) and use the static IP or DNS name.
+- uncomment the [volumes](docker-compose.yml#54) in the compose file to mount the macaroon and TLS certificate to the feeder service and change the [macaroons_path](feederd/config.json#L11) and [tls_cert_path](feederd/config.json#L12) to `/price.macaroon` and `/cert.pem` respectively.
+Last but not least, don't forget to open the port where the Operator interface listens to (default `9000`) and allow in-going and out-going traffic over it on your router.
 
 ### Onion
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ $ git clone https://github.com/TDex-network/tdex-box
 $ cd tdex-box
 ```
 
-2. Edit [feederd/config.json](https://github.com/TDex-network/tdex-feeder#config-file) file if you wish. By default it defines a market with LBTC-USDt and uses Kraken as price feed.
-
+2. Edit [feederd/config.json](https://github.com/TDex-network/tdex-feeder#config-file) file if you wish. By default it defines a market with LBTC-USDt and uses Kraken as price feed.  
 
 3. Export ENV variable for Esplora REST endpoint
 
@@ -23,16 +22,27 @@ $ export EXPLORER=zzz
 
 4. **OPTIONAL** TLS or Onion
 
-#### TLS
+### TLS
 
-Uncomment in the compose file (`docker-compose.yml`) the TLS related stuff and export ENV with the asbolute path to the SSL Certificate and Key to be used.
+#### Trade interface
+
+To enable TLS encryption on the Trade interface of the daemon, you have to generate your own TLS key and certificate files. Once this is done, export the ENV variables with the absolute path of the files: 
 
 ```sh
-$ export SSL_CERT_PATH=/path/to/fullchain.pem
-$ export SSL_KEY_PATH=/path/to/privatekey.pem
+$ export SSL_CERT_PATH=/path/to/certificate.crt
+$ export SSL_KEY_PATH=/path/to/privatekey.key
 ```
 
-#### Onion
+The last step is to uncomment in the compose file (`docker-compose.yml`) the lines related to TLS for Trade interface.
+
+#### Operator interface
+
+By default, the daemon service is configured to enable TLS encryption for the Operator interface. It's enough to uncomment [this line](docker-compose.yml#L18) to disable it.
+
+The generation of the TLS key and certificate file for this interface are up to the daemon itself.  
+If you want to run the box on a remote machine with a static IP (and possibly a DNS name), you need to uncomment one or both [these lines](docker-compose.yml#L21) to let the daemon create the right certificate that, for example, will allow you to use the Operator CLI remotely. Exceptionally for this case, if you are also going to run the feeder service, you'll need to change the [default address in its config file](feederd/config.json#L12) (default `tdexd`) and use the static IP or DNS name. Last but not least, don't forget to open the port where the Operator interface listens to (default `9000`) and allow in-going and out-going traffic over it on your router.
+
+### Onion
 
 Add this compose service at the bottom of the compose file (either `docker-compose.yml`)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,3 +50,6 @@ services:
       - tdexd
     volumes:
       - ./feederd/config.json:/config.json
+      # Uncomment to mount TLS cert and mac files sourced from daemon datadir on this service.
+      # - ./tdexd/macaroons/price.macaroon:/price.macaroon
+      # - ./tdexd/tls/cert.pem:/cert.pem

--- a/feederd/config.json
+++ b/feederd/config.json
@@ -1,13 +1,18 @@
 {
-  "daemon_endpoint": "tdexd:9000",
-  "daemon_macaroon": "",
-  "kraken_ws_endpoint": "ws.kraken.com",
+  "price_feeder": "kraken",
+  "interval": 300000,
   "markets": [
     {
       "base_asset": "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d",
       "quote_asset": "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2",
-      "kraken_ticker": "XBT/USDT",
-      "interval": 300000
+      "ticker": "XBT/USDT",
+      "targets": [
+        {
+          "macaroons_path": "",
+          "rpc_address": "tdexd:9000",
+          "tls_cert_path": ""
+        }
+      ]
     }
   ]
 }

--- a/feederd/config.json
+++ b/feederd/config.json
@@ -9,8 +9,8 @@
       "targets": [
         {
           "macaroons_path": "",
-          "rpc_address": "tdexd:9000",
-          "tls_cert_path": ""
+          "tls_cert_path": "",
+          "rpc_address": "tdexd:9000"
         }
       ]
     }


### PR DESCRIPTION
This updates the config file for the feeder  version v0.2.0. 
This also contains some changes to the README in order to improve the description of the TLS section, in an attempt to make an evident separation between TLS for Trade interface and Operator interface. For the latter, a brief explanation of how to set it up on a remote machine with static IP or DNS name has been added.

Please @tiero review this.